### PR TITLE
Split gh actions into two separate config files

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,12 +9,10 @@
 # - add a test stage to jobs
 
 
-name: Docker
+name: Deploy to Cloud Run
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test Action
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  # 🤖 CI paragraph
+  #
+  # uncomment the content of this paragraph to activate the tests in GitHub CI
+  # - remove the 2 trailing characters "# ", do not change the spaces
+  #   (the `name` keys should be at the same level as the `uses` key)
+  #   (the `strategy` key should be at the same level as the `steps` key)
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Say hello
+      run: |
+        echo "Hello, World!"
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Install package and test
+      run: |
+        make install test clean
+
+    strategy:
+      matrix:
+        python-version: [3.8]

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -1,0 +1,6 @@
+from cookit.predict import Predictor
+
+predictor = Predictor()
+
+def test_dummy():
+    pass


### PR DESCRIPTION
This PR should enable two actions: 
- CI tests should run for all pull_requests
- the deployment to Google Cloud should only run if the pul request request was merged into master, aka pushed to master